### PR TITLE
add detail to getActivities params

### DIFF
--- a/pyade/__init__.py
+++ b/pyade/__init__.py
@@ -247,7 +247,7 @@ class ADEWebAPI():
                     'codeZ', 'info', 'detail']), 
             'getActivities': set(['tree', 'id', 'name', 'resources', 'type', 'url', 
                     'capacity', 'duration', 'repetition', 'code', 'timezone', 'codeX', 
-                    'codeY', 'codeZ', 'maxSeats', 'seatseLeft', 'info']), 
+                    'codeY', 'codeZ', 'maxSeats', 'seatseLeft', 'info', 'detail']), 
             'getEvents': set(['eventId', 'activities', 'name', 'resources', 
                     'weeks', 'days', 'date', 'detail']), 
             'getCosts': set(['id', 'name']), 


### PR DESCRIPTION
Based on my test, ADE support `detail` using the `getActivities` function.